### PR TITLE
accounts for null values in gamestats

### DIFF
--- a/jej_events/presence.js
+++ b/jej_events/presence.js
@@ -34,7 +34,9 @@ function endLogging(uniqueName, id, gameName) {
         console.log("\tPlayed for " + seconds + " seconds.");
 
         // Add the current time to the existing one, and save the resulting JSON.
-        if (gameName in currStats) {
+        // If the time stored in gameName is null, then make sure to account for that case.
+        // Althought I have no idea why that happens on Raspberry Pi.
+        if (gameName in currStats && currStats[gameName] !== null)) {
             currStats[gameName] += seconds;
         } else {
             currStats[gameName] = seconds;

--- a/jej_events/presence.js
+++ b/jej_events/presence.js
@@ -26,6 +26,11 @@ function endLogging(uniqueName, id, gameName) {
         // Get the current time spent for the game.
         var seconds = GameStats.getTime(uniqueName, gameName);
 
+        // If undefined seconds, just exit and don't do anything.
+        if (seconds === undefined || seconds === null) {
+            return;
+        }
+
         console.log("\tPlayed for " + seconds + " seconds.");
 
         // Add the current time to the existing one, and save the resulting JSON.

--- a/jej_events/presence.js
+++ b/jej_events/presence.js
@@ -28,7 +28,7 @@ function endLogging(uniqueName, id, gameName) {
 
         // If undefined seconds, just exit and don't do anything.
         if (seconds === undefined || seconds === null) {
-            return;
+            console.log('WARNING: Seconds is ' + seconds);
         }
 
         console.log("\tPlayed for " + seconds + " seconds.");
@@ -62,7 +62,7 @@ function gameTracker(before, after) {
     // If a game has been quit, have it quit logging for that user.
     if (game) {
         // Since stat is async, create temp so value is stored.
-        var tempGame = game;
+
 
         // Make sure the user file exists. If not, create it.
         fs.stat(GameStats.filePathFromName(id, tempGame), (err, res) => {


### PR DESCRIPTION
- if a null time is stored, it automatically re-assigns the value to be the the latest time accounted for
- if a null time is about to be stored, a warning will be sent to console and nothing will happen
